### PR TITLE
[RunAllTests] - Code Coverage Analysis Report

### DIFF
--- a/scripts/src/java/org/oppia/android/scripts/coverage/reporter/CoverageReporter.kt
+++ b/scripts/src/java/org/oppia/android/scripts/coverage/reporter/CoverageReporter.kt
@@ -496,38 +496,16 @@ class CoverageReporter(
       }
     }
 
-    val skipCoverageReportText = buildString {
-      append("## Coverage Report\n")
-      append("### Results\n")
-      append("Coverage Analysis: **SKIP** :next_track_button:\n\n")
-      append("_This PR did not introduce any changes to Kotlin source or test files._\n\n")
-      append("#\n")
-      append("> To learn more, visit the [Oppia Android Code Coverage](https://github.com/oppia/oppia-android/wiki/Oppia-Android-Code-Coverage) wiki page")
-    }
-
-    val wikiPageLinkNote = buildString {
-      val wikiPageReferenceNote = ">To learn more, visit the [Oppia Android Code Coverage]" +
-        "(https://github.com/oppia/oppia-android/wiki/Oppia-Android-Code-Coverage) wiki page"
-      append("\n\n")
-      append("#")
-      append("\n")
-      append(wikiPageReferenceNote)
-    }
-
-    val finalReportText = coverageReportContainer.coverageReportList.takeIf { it.isNotEmpty() }
-      ?.let {
-        "## Coverage Report\n\n" +
-          "### Results\n" +
-          "Number of files assessed: ${coverageReportContainer.coverageReportList.size}\n" +
-          "Overall Coverage: **${"%.2f".format(calculateOverallCoveragePercentage())}%**\n" +
-          "Coverage Analysis: $status\n" +
-          "##" +
-          failureMarkdownTable +
-          failureMarkdownEntries +
-          successMarkdownEntries +
-          testFileExemptedSection +
-          wikiPageLinkNote
-      } ?: skipCoverageReportText
+    val finalReportText =  "## Coverage Report\n\n" +
+      "### Results\n" +
+      "Number of files assessed: ${coverageReportContainer.coverageReportList.size}\n" +
+      "Overall Coverage: **${"%.2f".format(calculateOverallCoveragePercentage())}%**\n" +
+      "Coverage Analysis: $status\n" +
+      "##" +
+      failureMarkdownTable +
+      failureMarkdownEntries +
+      successMarkdownEntries +
+      testFileExemptedSection 
 
     val finalReportOutputPath = mdReportOutputPath
       ?.let { it }

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -1,3 +1,5 @@
 Have an idea for how to improve the wiki? Please help make our documentation better by following our [instructions for contributing to the wiki.](https://github.com/oppia/oppia-android/wiki/Wiki#contributing-to-the-wiki)
 
 Fork for Fork
+
+RunAllTests


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [ ] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [ ] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [ ] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [ ] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [ ] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-A11y-Guide))
- For PRs introducing new UI elements or color changes, both light and dark mode screenshots must be included
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing
