### PR TITLE
Testing after reverted workflows and concurrency set with pr number and run id

### DIFF
--- a/app/src/main/java/org/oppia/android/app/home/HomeActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/home/HomeActivityPresenter.kt
@@ -13,7 +13,7 @@ import javax.inject.Inject
 
 const val TAG_HOME_FRAGMENT = "HOME_FRAGMENT"
 
-/** The presenter for [HomeActivity_]. */
+/** The presenter for [HomeActivity]. */
 @ActivityScope
 class HomeActivityPresenter @Inject constructor(private val activity: AppCompatActivity) {
   private var navigationDrawerFragment: NavigationDrawerFragment? = null

--- a/app/src/main/java/org/oppia/android/app/home/HomeActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/home/HomeActivityPresenter.kt
@@ -13,7 +13,7 @@ import javax.inject.Inject
 
 const val TAG_HOME_FRAGMENT = "HOME_FRAGMENT"
 
-/** The presenter for [HomeActivity]. */
+/** The presenter for [HomeActivity_]. */
 @ActivityScope
 class HomeActivityPresenter @Inject constructor(private val activity: AppCompatActivity) {
   private var navigationDrawerFragment: NavigationDrawerFragment? = null

--- a/scripts/src/java/org/oppia/android/scripts/common/GitClient.kt
+++ b/scripts/src/java/org/oppia/android/scripts/common/GitClient.kt
@@ -5,7 +5,7 @@ import java.io.File
 /**
  * General utility for interfacing with a Git repository located at the specified working directory
  * and using the specified base commit hash reference that should be used when computing changes
- * from the local branch.
+ * from the local - branch.
  */
 class GitClient(
   private val workingDirectory: File,


### PR DESCRIPTION
**FORK**

- [x] Pass report - [PR](https://github.com/Rd4dev/Oppia-Android-Fork-from-Fork/pull/33)  |  [report](https://github.com/Rd4dev/Oppia-Android-Fork-from-Fork/pull/32#issuecomment-2307432297)
- [x] Fail check should not auto merge - [PR](https://github.com/Rd4dev/Oppia-Android-Fork-from-Fork/pull/34)  |  [report](https://github.com/Rd4dev/Oppia-Android-Fork-from-Fork/pull/34#issuecomment-2307427416)  |  [stack trace](https://github.com/Rd4dev/Oppia-Android-Fork-from-Fork/actions/runs/10528043558/job/29175484472)
- [x] Skip report - [PR](https://github.com/Rd4dev/Oppia-Android-Fork-from-Fork/pull/33)  |  [report](https://github.com/Rd4dev/Oppia-Android-Fork-from-Fork/pull/33#issuecomment-2307386920)  |  [stack trace](https://github.com/Rd4dev/Oppia-Android-Fork-from-Fork/actions/runs/10528004543/job/29174628791?pr=33)

**UPSTREAM**

- [x] Pass report - [PR](https://github.com/Rd4dev/Oppia-Android-Fork-from-Fork/pull/35)  |  [report](https://github.com/Rd4dev/Oppia-Android-Fork-from-Fork/pull/35#issuecomment-2307427436)
- [x] Fail check should not auto merge - [PR](https://github.com/Rd4dev/Oppia-Android-Fork-from-Fork/pull/36)  |  [report](https://github.com/Rd4dev/Oppia-Android-Fork-from-Fork/pull/36#issuecomment-2307434018)  |  [stack trace](https://github.com/Rd4dev/Oppia-Android-Fork-from-Fork/actions/runs/10528226456/job/29176104189?pr=36)
- [x] Skip report - [PR](https://github.com/Rd4dev/Oppia-Android-Fork-from-Fork/pull/37)  |  [report](https://github.com/Rd4dev/Oppia-Android-Fork-from-Fork/pull/37#issuecomment-2307404209)  |  [stack trace](https://github.com/Rd4dev/Oppia-Android-Fork-from-Fork/actions/runs/10528231082/job/29175249805?pr=37)

**Concurrency within PR**

- [x] Concurrency within PR cancels right: [workflow actions](https://github.com/Rd4dev/Oppia-Android-Fork-from-Fork/actions)  |  [concurrency cancel trigger](https://github.com/Rd4dev/Oppia-Android-Fork-from-Fork/pull/32/checks?check_run_id=29174576879)

![image](https://github.com/user-attachments/assets/f2be32fa-9d0e-41f7-8f60-82771e748592)

**Concurrency in develop merge on: push**

- [x] Concurrency with develop merge does not cancel other merge checks: [workflow actions](https://github.com/Rd4dev/Oppia-Android-Fork-from-Fork/actions)
Merge checks from both PR 35 and PR 37 runs at the same time without cancelling after grouping concurrency with: 
```
${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
```

![image](https://github.com/user-attachments/assets/939c0aa1-dfcc-4bcb-9f67-6d4aea7d3f5e)

<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [ ] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [ ] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [ ] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [ ] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [ ] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-A11y-Guide))
- For PRs introducing new UI elements or color changes, both light and dark mode screenshots must be included
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing
