### PR TITLE
Skipping with auto merge - upstream

### DIFF
--- a/wiki/Triaging-process.md
+++ b/wiki/Triaging-process.md
@@ -4,7 +4,7 @@ This wiki outlines the steps to triage new and existing issues. This ensures tha
 ###  First-stage triage - Steps to triage incoming issues coming into Oppia-Android as a whole:
 The Dev Workflow team lead (currently Ben) should do the following every week for any [filed issues that aren’t assigned to a project](https://github.com/oppia/oppia-android/issues?q=is%3Aissue+is%3Aopen+no%3Aproject):
 
-- Check that the issue is written clearly enough. Request clarification if needed.
+- Check that the issue is written clearly enough. Request clarification if - needed.
 - Assign the issue to the appropriate task force, if applicable. Otherwise, assign it to the relevant team (CLAM, Dev Workflow) based on which type of user it affects.
 - If you’re not sure how to categorise an issue, feel free to ping Sean (@seanlip) for help!
 


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [ ] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [ ] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [ ] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [ ] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [ ] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-A11y-Guide))
- For PRs introducing new UI elements or color changes, both light and dark mode screenshots must be included
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing
