### PR TITLE
Sync race snippet

### DIFF
--- a/app/src/test/java/org/oppia/android/app/testing/PlatformParameterIntegrationTest.kt
+++ b/app/src/test/java/org/oppia/android/app/testing/PlatformParameterIntegrationTest.kt
@@ -188,7 +188,7 @@ class PlatformParameterIntegrationTest {
   @Test
   fun testIntegration_updateEmptyDatabase_readDatabase_checkWelcomeMsgIsVisible() {
     platformParameterController.updatePlatformParameterDatabase(
-      mockPlatformParameterListWithToastEnabled
+      mockPlatformParameterListWithToastDisabled
     )
     testCoroutineDispatchers.runCurrent()
 

--- a/domain/src/main/java/org/oppia/android/domain/platformparameter/PlatformParameterController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/platformparameter/PlatformParameterController.kt
@@ -11,6 +11,7 @@ import org.oppia.android.util.data.DataProviders.Companion.transform
 import org.oppia.android.util.platformparameter.PlatformParameterSingleton
 import javax.inject.Inject
 import javax.inject.Singleton
+import java.lang.Thread
 
 /** Controller for fetching and updating platform parameters in the database. */
 @Singleton
@@ -38,17 +39,22 @@ class PlatformParameterController @Inject constructor(
   }
 
   private val platformParameterDataProvider by lazy {
-    // After this transformation the cached List of Platform Parameters gets converted into a simple
-    // map where the keys corresponds to the name of Platform Parameter and value will correspond to
-    // the PlatformParameter object itself
-    platformParameterDatabaseStore.transform(PLATFORM_PARAMETER_DATA_PROVIDER_ID) {
-      platformParameterDatabase ->
-      val platformParameterMap = mutableMapOf<String, PlatformParameter>()
+    platformParameterDatabaseStore.transform(PLATFORM_PARAMETER_DATA_PROVIDER_ID) { platformParameterDatabase ->
+      Thread.sleep(50000L)
+      var platformParameterMap = mutableMapOf<String, PlatformParameter>()
+
       platformParameterDatabase.platformParameterList.forEach {
         platformParameterMap[it.name] = it
       }
+
+      val mockSplashScreenWelcomeMsgParam = PlatformParameter.newBuilder()
+        .setName("splash_screen_welcome_msg")
+        .setBoolean(true)
+        .build()
+
+      platformParameterMap["splash_screen_welcome_msg"] = mockSplashScreenWelcomeMsgParam
+
       platformParameterSingleton.setPlatformParameterMap(platformParameterMap)
-      return@transform
     }
   }
 

--- a/testing/src/main/java/org/oppia/android/testing/threading/TestCoroutineDispatcherRobolectricImpl.kt
+++ b/testing/src/main/java/org/oppia/android/testing/threading/TestCoroutineDispatcherRobolectricImpl.kt
@@ -127,7 +127,7 @@ class TestCoroutineDispatcherRobolectricImpl private constructor(
     }
     runBlocking {
       try {
-        withTimeout(timeoutMillis) {
+        withTimeout(60000L) {
           flushTaskDeferred.await()
         }
       } catch (e: TimeoutCancellationException) {


### PR DESCRIPTION

Test run:
```
bazel test app:src/test/java/org/oppia/android/app/testing/PlatformParameterIntegrationTest 
    --test_filter=testIntegration_updateEmptyDatabase_readDatabase_checkWelcomeMsgIsVisible
```

Retrieving / Utilizing the `platformParameterMap` value -- delaying 50 seconds.

![image](https://github.com/user-attachments/assets/d2625323-c62d-425e-ac80-5912c452a63b)

--- 

when mock value is set to `false`

```
val mockSplashScreenWelcomeMsgParam = PlatformParameter.newBuilder()
        .setName("splash_screen_welcome_msg")
        .setBoolean(false)
        .build()
```

![image](https://github.com/user-attachments/assets/2db52a76-5de8-407a-8eda-07dd593b69c9)
